### PR TITLE
using entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ ADD server.js /app/
 
 EXPOSE 1337
 
-CMD ["/nodejs/bin/node", "server.js"]
+ENTRYPOINT ["/nodejs/bin/node", "server.js"]


### PR DESCRIPTION
Use ENTRYPOINT instead of CMD to make the container behave more like an own application. You shouldn't want to overwrite CMD. And it's possible to use args with the container.